### PR TITLE
Declare the example hw interface as a dependency for the rostest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,7 @@ if(CATKIN_ENABLE_TESTING)
 
   find_package(rostest REQUIRED)
 
-  add_rostest(test/pass_through_controllers.test)
+  add_rostest(test/pass_through_controllers.test DEPENDENCIES hw_interface_example)
 endif()
 
 ## Add gtest based cpp test target and link libraries

--- a/package.xml
+++ b/package.xml
@@ -75,6 +75,7 @@
   <test_depend>cartesian_trajectory_controller</test_depend>
   <test_depend>control_msgs</test_depend>
   <test_depend>controller_manager_msgs</test_depend>
+  <test_depend>robot_state_publisher</test_depend>
   <test_depend>rospy</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>tf</test_depend>


### PR DESCRIPTION
As the rostests are relying on a local target to be built, we should declare this as a dependency.

Additionally, there seems to be a missing depend on `robot_state_publisher` as it is used by a launchfile [included from another package's tests](https://github.com/UniversalRobots/Universal_Robots_ROS_passthrough_controllers/blob/main/test/launch/robot.launch#L3).

As `cartesian_trajectory_controller` doesn't export `robot_state_publisher` as a direct dependency, it isn't installed inside the local tests here.

I think, we could either
 - recreate the setup here with all dependencies
 - add `robot_state_publisher` to this package's test depends in order for it to be present here.

I would vote for the first option. @stefanscherzinger what do you think?