### PR TITLE
Added mising test dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -75,7 +75,10 @@
   <test_depend>cartesian_trajectory_controller</test_depend>
   <test_depend>control_msgs</test_depend>
   <test_depend>controller_manager_msgs</test_depend>
+  <test_depend>joint_state_controller</test_depend>
+  <test_depend>joint_trajectory_controller</test_depend>
   <test_depend>robot_state_publisher</test_depend>
+  <test_depend>ros_control_boilerplate</test_depend>
   <test_depend>rospy</test_depend>
   <test_depend>rostest</test_depend>
   <test_depend>tf</test_depend>


### PR DESCRIPTION
As risen in #5 our tests depend on test_dependencies of `cartesian_trajectory_controller`. This didn't show up, as we were building `cartesian_trajectory_controller` inside our pipeline inside the upstream workspace, so the dependencies were all there. When using the released binary packages of upstream packages, those test dependencies don't get pulled by rosdep.

As mentioned in #5 a proper solution would be to use a separate package for setting up the testing scenario that properly exports its launch dependencies as `exec_depend`s, but until then, let's add those testing dependencies to this package.